### PR TITLE
fix zstd conditional cfg, change  SHA256 to SHA384 checksums

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "Uinelj"
+      - "pjox"

--- a/src/ops/compress.rs
+++ b/src/ops/compress.rs
@@ -219,7 +219,9 @@ mod test {
 
     use tempfile::tempdir;
 
-    use crate::ops::{compress::compress_zstd, Compress};
+    #[cfg(feature = "zstd")]
+    use crate::ops::compress::compress_zstd;
+    use crate::ops::Compress;
 
     use super::compress;
 
@@ -237,6 +239,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "zstd")]
     fn test_compress_ztd() {
         // create content and compress
         let content = "foo";


### PR DESCRIPTION
zstd being optional in the implementations while being necessary in the tests caused errors

this change allows oscar-tools to build successfully again.